### PR TITLE
Tags added

### DIFF
--- a/chromeExt/styles.css
+++ b/chromeExt/styles.css
@@ -1,5 +1,11 @@
 .videowall-endscreen,
 .watch-sidebar,
-.feed-item-container {
+.feed-item-container,
+ytd-browse {
 	visibility: hidden;
+}
+
+#related {
+	visibility: hidden;
+	height: 0px;
 }

--- a/ytRecommendedBlocker.safariextension/styles.css
+++ b/ytRecommendedBlocker.safariextension/styles.css
@@ -1,5 +1,11 @@
 .videowall-endscreen,
 .watch-sidebar,
-.feed-item-container {
+.feed-item-container,
+ytd-browse {
 	visibility: hidden;
+}
+
+#related {
+	visibility: hidden;
+	height: 0px;
 }


### PR DESCRIPTION
Added tags to hide front page videos and related videos on each page. 0px in #related b/c if you go into narrow mode, the related section will be a huge swath of blank space until you reach the comments.

Edit: obviously to introduce compatibility with new YT UI design, as the current version only hides content in the old UI. #2 #3 